### PR TITLE
Use fully-specified imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ the comments and *flag* function calls found in your .go files.
 
 Execute
 ```bash
-go build mango.go
+go install github.com/slyrz/mango
 ```
 to build mango.
 

--- a/mango.go
+++ b/mango.go
@@ -10,13 +10,14 @@
 package main
 
 import (
-	"./markup"
-	"./source"
 	"flag"
 	"fmt"
 	"os"
 	"path"
 	"strings"
+
+	"github.com/slyrz/mango/markup"
+	"github.com/slyrz/mango/source"
 )
 
 var (


### PR DESCRIPTION
This allows Mango to be installed with the standard `go get` command and fixes #1.
